### PR TITLE
Load JVM Cleanup and Fix for 0.4

### DIFF
--- a/src/JavaCall.jl
+++ b/src/JavaCall.jl
@@ -74,7 +74,7 @@ function findjvm()
         push!(libpaths, joinpath(n, "jre", "lib", "server"))
     end
     
-    ext = "."*@windows? "dll":@osx? " dylib":"so"
+    ext = "."*@windows? "dll":@osx? "dylib":"so"
     try 
         for n in libpaths
             libpath = joinpath(n,libname*ext);


### PR DESCRIPTION
A fix for the macros `@windows` and `@osx` that fail on 0.4.x preventing use by Julia 0.4. 
Removed deprecations
Removed spurious load error messages.