### PR TITLE
Renaming of JClass to JavaClass

### DIFF
--- a/src/JavaCall.jl
+++ b/src/JavaCall.jl
@@ -1,5 +1,5 @@
 module JavaCall
-export JavaObject, JavaClass, JString, jint, jlong, jbyte, jboolean, jchar, jshort, jfloat, jdouble, JObject, 
+export JavaObject, JavaMetaClass, JString, jint, jlong, jbyte, jboolean, jchar, jshort, jfloat, jdouble, JObject, 
 	   @jimport, jcall, isnull
 
 # using Debug
@@ -116,12 +116,12 @@ end
 include("jnienv.jl")
 
 
-immutable JavaClass{T}
+immutable JavaMetaClass{T}
 	ptr::Ptr{Void}
 end
 
 #The metaclass, sort of equivalent to a java.lang.Class<T>
-JavaClass(T, ptr) = JavaClass{T}(ptr)
+JavaMetaClass(T, ptr) = JavaMetaClass{T}(ptr)
 
 type JavaObject{T}
 	ptr::Ptr{Void}
@@ -201,13 +201,13 @@ function jnew(T::Symbol, argtypes::Tuple, args...)
 end
 
 isnull(obj::JavaObject) = obj.ptr == C_NULL
-isnull(obj::JavaClass) = obj.ptr == C_NULL
+isnull(obj::JavaMetaClass) = obj.ptr == C_NULL
 
 @memoize function metaclass(class::Symbol)
 	jclass=javaclassname(class)
 	jclassptr = ccall(jnifunc.FindClass, Ptr{Void}, (Ptr{JNIEnv}, Ptr{Uint8}), penv, jclass)
 	if jclassptr == C_NULL; error("Class Not Found $jclass"); end
-	return JavaClass(class, jclassptr)
+	return JavaMetaClass(class, jclassptr)
 end
 
 metaclass{T}(::Type{JavaObject{T}}) = metaclass(T)
@@ -246,7 +246,7 @@ if VERSION < v"0.4-"
 else
 	const unsafe_convert = Base.unsafe_convert
 end
-unsafe_convert(::Type{Ptr{Void}}, cls::JavaClass) = cls.ptr
+unsafe_convert(::Type{Ptr{Void}}, cls::JavaMetaClass) = cls.ptr
 
 # Call static methods
 function jcall{T}(typ::Type{JavaObject{T}}, method::String, rettype::Type, argtypes::Tuple, args... )
@@ -333,7 +333,7 @@ jvalue(v::Ptr) = jvalue(@compat Int(v))
 
 # Get the JNI/C type for a particular Java type
 function real_jtype(rettype)
-	if issubtype(rettype, JavaObject) || issubtype(rettype, Array) || issubtype(rettype, JavaClass)
+	if issubtype(rettype, JavaObject) || issubtype(rettype, Array) || issubtype(rettype, JavaMetaClass)
 		jnitype = Ptr{Void}
 	else 
 		jnitype = rettype


### PR DESCRIPTION
Currently `JClass` isn't consistent with other `J*` types, which results in some confusion (e.g. see discussion in #11). This PR simply renames `JClass` to `JavaClass`, both - avoiding confusion and freeing name `JClass` to be used for `java.lang.Class`. 