### PR TITLE
Reflection API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*~
+.juliahistory

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.3
 Memoize
 Compat
+Dates

--- a/doc/_config.yml
+++ b/doc/_config.yml
@@ -1,5 +1,5 @@
 lsi: false
-pygments: true
+highlighter: pygments
 markdown: redcarpet
 redcarpet:
   extensions: ["no_intra_emphasis", "fenced_code_blocks", "autolink", "tables", "with_toc_data", "hard_wrap"]

--- a/src/JavaCall.jl
+++ b/src/JavaCall.jl
@@ -1,6 +1,9 @@
 module JavaCall
-export JavaObject, JavaMetaClass, JString, jint, jlong, jbyte, jboolean, jchar, jshort, jfloat, jdouble, JObject, 
-	   @jimport, jcall, isnull
+export JavaObject, JavaMetaClass, 
+       jint, jlong, jbyte, jboolean, jchar, jshort, jfloat, jdouble, 
+       JObject, JClass, JMethod, JString, 
+       @jimport, jcall, isnull,
+       getname, listmethods, getreturntype, getparametertypes
 
 # using Debug
 using Memoize
@@ -545,6 +548,6 @@ function destroy()
 	global penv=C_NULL; global pjvm=C_NULL; 
 end
 
-
+include("reflect.jl")
 
 end # module

--- a/src/reflect.jl
+++ b/src/reflect.jl
@@ -1,0 +1,57 @@
+
+using JavaCall
+using Compat
+
+if !JavaCall.isloaded()
+    JavaCall.init([])
+end
+
+JJClass = @jimport java.lang.Class
+JMethod = @jimport java.lang.reflect.Method
+
+function getclass(obj::JavaObject)
+    jcall(obj, "getClass", JJClass, ())
+end
+
+function conventional_name(name::String)
+    if @compat startswith(name, "[")
+        return conventional_name(name[2:end]) * "[]"
+    elseif name == "Z"
+        return "boolean"
+    elseif name == "B"
+        return "byte"
+    elseif name == "C"
+        return "char"
+    elseif name == "I"
+        return "int"
+    elseif name == "J"
+        return "long"
+    elseif name == "F"
+        return "float"
+    elseif name == "D"
+        return "double"
+    elseif name == "V"
+        return "void"
+    else
+        return name
+    end
+end
+
+function getclassname(cls::JJClass)
+    rawname = jcall(cls, "getName", JString, ())
+    return conventional_name(rawname)
+end
+
+function listmethods(obj::JavaObject)
+    cls = getclass(obj)
+    methods = jcall(cls, "getMethods", Vector{JMethod}, ())
+end
+
+function Base.show(io::IO, method::JMethod)
+    name = jcall(method, "getName", JString, ())
+    rettype = getclassname(jcall(method, "getReturnType", JJClass, ()))
+    argtypes = [getclassname(c) for c in
+                jcall(method, "getParameterTypes", Vector{JJClass}, ())]
+    argtypestr = join(argtypes, ", ")
+    print(io, "$rettype $name($argtypestr)")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,9 +21,9 @@ T = @jimport Test
 @test typemax(jlong) == jcall(T, "testLong", jlong, (jlong,), typemax(jlong))
 @test "Hello Java"==jcall(T, "testString", JString, (JString,), "Hello Java")
 @test @compat Float64(10.02) == jcall(T, "testDouble", jdouble, (jdouble,), 10.02) #Comparing exact float representations hence ==
-@test @compat Float32(10.02) == jcall(T, "testFloat", jfloat, (jfloat,), 10.02)  
-@test realmax(jdouble) == jcall(T, "testDouble", jdouble, (jdouble,), realmax(jdouble)) 
-@test realmax(jfloat) == jcall(T, "testFloat", jfloat, (jfloat,), realmax(jfloat))  
+@test @compat Float32(10.02) == jcall(T, "testFloat", jfloat, (jfloat,), 10.02)
+@test realmax(jdouble) == jcall(T, "testDouble", jdouble, (jdouble,), realmax(jdouble))
+@test realmax(jfloat) == jcall(T, "testFloat", jfloat, (jfloat,), realmax(jfloat))
 
 c=JString(C_NULL)
 @test isnull(c)
@@ -73,15 +73,22 @@ a=jcall(j_u_arrays, "copyOf", Array{JObject, 1}, (Array{JObject, 1}, jint), ["a"
 gc()
 # Test Memory allocation and de-allocatios
 # the following loop fails with an OutOfMemoryException in the absence of de-allocation
-# However, since Java and Julia memory are not linked, and manual gc() is required. 
+# However, since Java and Julia memory are not linked, and manual gc() is required.
 for i in 1:100000
-	a=JString("A"^10000); #deleteref(a); 
+	a=JString("A"^10000); #deleteref(a);
 	if (i%10000 == 0); gc(); end
 end
 
 #Test for Issue #8
 @test_throws ErrorException jcall(jlm, "sinx", jdouble, (jdouble,), 1.0)
 @test_throws ErrorException jcall(jlm, "sinx", jdouble, (jdouble,), 1.0)
+
+@test length(listmethods(JString("test"))) == 72
+@test length(listmethods(JString("test"), "indexOf")) == 4
+m = listmethods(JString("test"), "indexOf")[1]
+@test getname(getreturntype(m)) == "int"
+@test [getname(typ) for typ in getparametertypes(m)] == ["java.lang.String", "int"]
+
 
 # At the end, unload the JVM before exiting
 JavaCall.destroy()


### PR DESCRIPTION
Sometimes, especially when working with Scala, it turns out to be terribly hard to figure out correct method signature. This PR adds a couple of useful functions for listing and inspecting Java methods. Here's an example of usage:

```
julia> listmethods(JString("test"))
72-element Array{JavaObject{symbol("java.lang.reflect.Method")},1}:
 boolean equals(java.lang.Object)              
 java.lang.String toString()                   
 int hashCode()                                
 int compareTo(java.lang.Object)               
 int compareTo(java.lang.String)               
 int indexOf(java.lang.String, int)            
 int indexOf(java.lang.String)                 
 int indexOf(int)                              
 int indexOf(int, int)                         
 java.lang.String valueOf(char)                
 ⋮                                             
 java.lang.String copyValueOf(char[])          
 java.lang.String copyValueOf(char[], int, int)
 java.lang.String intern()                     
 void wait(long, int)                          
 void wait(long)                               
 void wait()                                   
 java.lang.Class getClass()                    
 void notify()                                 
 void notifyAll()                              

julia> listmethods(JString("test"), "indexOf")
4-element Array{JavaObject{symbol("java.lang.reflect.Method")},1}:
 int indexOf(java.lang.String, int)
 int indexOf(java.lang.String)     
 int indexOf(int)                  
 int indexOf(int, int)
```
