### PR TITLE
Removed @memoize to get tests to pass

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -5,7 +5,7 @@ typealias jint Cint
 # typedef long jlong;
 typealias jlong Clonglong
 typealias jbyte Cchar
- 
+
 # jni.h
 
 typealias jboolean Cuchar
@@ -20,17 +20,17 @@ immutable JavaMetaClass{T}
     ptr::Ptr{Void}
 end
 
-#The metaclass, sort of equivalent to a the 
+#The metaclass, sort of equivalent to a the
 JavaMetaClass(T, ptr) = JavaMetaClass{T}(ptr)
 
 type JavaObject{T}
     ptr::Ptr{Void}
-    
+
     function JavaObject(ptr)
         j=new(ptr)
         finalizer(j, deleteref)
         return j
-    end 
+    end
 
     JavaObject(argtypes::Tuple, args...) = jnew(T, argtypes, args...)
 
@@ -60,7 +60,7 @@ function JString(str::AbstractString)
     jstring = ccall(jnifunc.NewStringUTF, Ptr{Void}, (Ptr{JNIEnv}, Ptr{UInt8}), penv, utf8(str))
     if jstring == C_NULL
         geterror()
-    else 
+    else
         return JString(jstring)
     end
 end
@@ -103,15 +103,15 @@ function jcall{T}(typ::Type{JavaObject{T}}, method::AbstractString, rettype::Typ
     try
         gc_enable(false)
         sig = method_signature(rettype, argtypes...)
-        
+
         jmethodId = ccall(jnifunc.GetStaticMethodID, Ptr{Void}, (Ptr{JNIEnv}, Ptr{Void}, Ptr{UInt8}, Ptr{UInt8}), penv, metaclass(T), utf8(method), sig)
         if jmethodId==C_NULL; geterror(true); end
-        
+
         _jcall(metaclass(T), jmethodId, C_NULL, rettype, argtypes, args...)
     finally
         gc_enable(true)
     end
-    
+
 end
 
 # Call instance methods
@@ -148,7 +148,7 @@ for (x, y, z) in [ (:jboolean, :(jnifunc.GetBooleanField), :(jnifunc.GetStaticBo
                   (:jfloat, :(jnifunc.GetFloatField), :(jnifunc.GetStaticFloatField)),
                   (:jdouble, :(jnifunc.GetDoubleField), :(jnifunc.GetStaticDoubleField)) ]
 
-    m = quote 
+    m = quote
         function _jfield(obj, jfieldID::Ptr{Void}, fieldType::Type{$(x)})
             callmethod = ifelse( typeof(obj)<:JavaObject, $y , $z )
             result = ccall(callmethod, $x, (Ptr{JNIEnv}, Ptr{Void}, Ptr{Void}), penv, obj.ptr, jfieldID)
@@ -212,7 +212,7 @@ function _jcall(obj,  jmethodId::Ptr{Void}, callmethod::Ptr{Void}, rettype::Type
     return convert_result(rettype, result)
 end
 
-@memoize function metaclass(class::Symbol)
+function metaclass(class::Symbol)
     jclass=javaclassname(class)
     jclassptr = ccall(jnifunc.FindClass, Ptr{Void}, (Ptr{JNIEnv}, Ptr{UInt8}), penv, jclass)
     if jclassptr == C_NULL; error("Class Not Found $jclass"); end
@@ -226,7 +226,7 @@ javaclassname(class::Symbol) = utf8(replace(string(class), '.', '/'))
 
 function geterror(allow=false)
     isexception = ccall(jnifunc.ExceptionCheck, jboolean, (Ptr{JNIEnv},), penv )
-    
+
     if isexception == JNI_TRUE
         jthrow = ccall(jnifunc.ExceptionOccurred, Ptr{Void}, (Ptr{JNIEnv},), penv)
         if jthrow==C_NULL ; error("Java Exception thrown, but no details could be retrieved from the JVM"); end


### PR DESCRIPTION
Tests were complaining that `metaclass` already existed and couldn't be defined again. Removing `@memoize` did the trick.