### PR TITLE
Fix init() when classpath has not been set

### DIFF
--- a/src/jvm.jl
+++ b/src/jvm.jl
@@ -141,7 +141,6 @@ assertnotloaded() = isloaded()?error("JVM already initialised"):nothing
 
 # Pointer to pointer to pointer to pointer alert! Hurrah for unsafe load
 function init{T<:AbstractString}(opts::Array{T, 1})
-    println("kek")
     assertnotloaded()
     opt = Array(JavaVMOption, length(opts))
     for i in 1:length(opts)

--- a/src/jvm.jl
+++ b/src/jvm.jl
@@ -126,7 +126,13 @@ opts=Array(String, 0)
 addClassPath(s::String) = isloaded()?warn("JVM already initialised. This call has no effect"): push!(cp, s)
 addOpts(s::String) = isloaded()?warn("JVM already initialised. This call has no effect"): push!(opts, s)
 
-init() = init(vcat(opts, reduce((x,y)->string(x,sep,y),"-Djava.class.path=$(cp[1])",cp[2:end]) ))
+function init()
+    if isempty(cp)
+        init(AbstractString[])
+    else
+        init(vcat(opts, reduce((x,y)->string(x,sep,y),"-Djava.class.path=$(cp[1])",cp[2:end])))
+    end
+end
 
 isloaded() = isdefined(JavaCall, :jnifunc) && isdefined(JavaCall, :penv) && penv != C_NULL
 
@@ -135,6 +141,7 @@ assertnotloaded() = isloaded()?error("JVM already initialised"):nothing
 
 # Pointer to pointer to pointer to pointer alert! Hurrah for unsafe load
 function init{T<:AbstractString}(opts::Array{T, 1})
+    println("kek")
     assertnotloaded()
     opt = Array(JavaVMOption, length(opts))
     for i in 1:length(opts)

--- a/src/jvm.jl
+++ b/src/jvm.jl
@@ -128,7 +128,7 @@ addOpts(s::String) = isloaded()?warn("JVM already initialised. This call has no 
 
 function init()
     if isempty(cp)
-        init(AbstractString[])
+        init(opts)
     else
         init(vcat(opts, reduce((x,y)->string(x,sep,y),"-Djava.class.path=$(cp[1])",cp[2:end])))
     end


### PR DESCRIPTION
Calling init() crashes when classpath has not been set explicitly.
This commit fixes the issue by initializing the JVM with the default
classpath when init() is called without any classpath.